### PR TITLE
Specify `/usr/bin/python2`

### DIFF
--- a/weather.15m.py
+++ b/weather.15m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 """Docstring"""
 


### PR DESCRIPTION
This should work on systems where the default is python3, like, Arch, and some others, without breaking anything on systems that default to python2

(Thanks for making this plugin; it's amazing!)